### PR TITLE
fix: CI tarball creation with conditional assets directory

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -36,7 +36,8 @@ jobs:
           path: |
             docs/molstar-components.js
             docs/molstar-components.css
-            docs/assets/
+            docs/editor.worker.js
+            docs/ts.worker.js
 
       - name: Upload Pages artifact
         uses: actions/upload-pages-artifact@v4
@@ -53,7 +54,8 @@ jobs:
           tar -czf ../molstar-components-${{ github.ref_name }}.tar.gz \
             molstar-components.js \
             molstar-components.css \
-            $([ -d assets ] && echo "assets/" || echo "")
+            editor.worker.js \
+            ts.worker.js
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2


### PR DESCRIPTION
## Problem
CI was failing when creating release tarball:
```
tar: assets: Cannot stat: No such file or directory
```

## Solution
- Change to  directory before creating tarball
- Conditionally include  only if it exists
- Move tarball to parent directory after creation

## Testing
This will fix the tar error and allow releases to complete successfully.