### PR TITLE
fix: use unique Monaco model URIs to prevent conflicts with multiple …

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@zachcp/molstar-components",
-  "version": "0.4.12",
+  "version": "0.4.13",
   "license": "MIT",
   "exports": "./src/mod.ts",
   "imports": {


### PR DESCRIPTION
…editors

- Add module-level counter to generate unique URIs for each editor instance
- Change hardcoded 'file:///main.js' to 'file:///main-{counter}.js'
- Add proper model disposal in cleanup to free memory
- Fixes 'ModelService: Cannot add model because it already exists!' error
- Bump version to 0.4.13